### PR TITLE
Fix bad signature of run

### DIFF
--- a/python/restate/context.py
+++ b/python/restate/context.py
@@ -95,7 +95,7 @@ class Context(abc.ABC):
     def run(self,
             name: str,
             action: RunAction[T],
-            serde: Serde[T] = JsonSerde()) -> Awaitable[T | None]:
+            serde: Serde[T] = JsonSerde()) -> Awaitable[T]:
         """
         Runs the given action with the given name.
         """

--- a/python/restate/server_context.py
+++ b/python/restate/server_context.py
@@ -12,7 +12,7 @@
 
 from datetime import timedelta
 import inspect
-from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar, cast
 import typing
 import traceback
 
@@ -230,13 +230,13 @@ class ServerInvocationContext(ObjectContext):
     async def run(self,
                   name: str,
                   action: Callable[[], T] | Callable[[], Awaitable[T]],
-                  serde: Optional[Serde[T]] = JsonSerde()) -> T | None:
+                  serde: Optional[Serde[T]] = JsonSerde()) -> T:
         assert serde is not None
         res = self.vm.sys_run_enter(name)
         if isinstance(res, Failure):
             raise TerminalError(res.message, res.code)
         if isinstance(res, bytes):
-            return serde.deserialize(res)
+            return cast(T, serde.deserialize(res))
         # the side effect was not executed before, so we need to execute it now
         assert res is None
         try:


### PR DESCRIPTION
The signature of run mistakenly returned `T | None`, but this didn't make a lot of sense because it actually returns always `T` (including when T itself is None)