### PR TITLE
Add support for pydantic

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,8 +18,8 @@ mypy:
 # Recipe to run pylint for linting
 pylint:
     @echo "Running pylint..."
-    {{python}} -m pylint python/restate
-    {{python}} -m pylint examples/
+    {{python}} -m pylint python/restate --ignore-paths='^.*.?venv.*$'
+    {{python}} -m pylint examples/ --ignore-paths='^.*\.?venv.*$'
 
 test:
     @echo "Running Python tests..."

--- a/python/restate/discovery.py
+++ b/python/restate/discovery.py
@@ -113,6 +113,14 @@ def compute_discovery_json(endpoint: RestateEndpoint,
     headers = {"content-type": "application/vnd.restate.endpointmanifest.v1+json"}
     return (headers, json_str)
 
+def try_extract_json_schema(model: Any) -> typing.Optional[typing.Any]:
+    """
+    Try to extract the JSON schema from a schema object
+    """
+    if model:
+        return model.model_json_schema(mode='serialization')
+    return None
+
 def compute_discovery(endpoint: RestateEndpoint, discovered_as : typing.Literal["bidi", "request_response"]) -> Endpoint:
     """
     return restate's discovery object for an endpoint
@@ -131,11 +139,11 @@ def compute_discovery(endpoint: RestateEndpoint, discovered_as : typing.Literal[
             # input
             inp = InputPayload(required=False,
                                contentType=handler.handler_io.accept,
-                               jsonSchema=None)
+                               jsonSchema=try_extract_json_schema(handler.handler_io.pydantic_input_model))
             # output
             out = OutputPayload(setContentTypeIfEmpty=False,
                                 contentType=handler.handler_io.content_type,
-                                jsonSchema=None)
+                                jsonSchema=try_extract_json_schema(handler.handler_io.pydantic_output_model))
             # add the handler
             service_handlers.append(Handler(name=handler.name, ty=ty, input=inp, output=out))
 

--- a/python/restate/object.py
+++ b/python/restate/object.py
@@ -85,8 +85,8 @@ class VirtualObject:
             def wrapped(*args, **kwargs):
                 return fn(*args, **kwargs)
 
-            arity = len(inspect.signature(fn).parameters)
-            handler = make_handler(self.service_tag, handler_io, name, kind, wrapped, arity)
+            signature = inspect.signature(fn)
+            handler = make_handler(self.service_tag, handler_io, name, kind, wrapped, signature)
             self.handlers[handler.name] = handler
             return wrapped
 

--- a/python/restate/serde.py
+++ b/python/restate/serde.py
@@ -108,6 +108,43 @@ class JsonSerde(Serde[I]):
         return bytes(json.dumps(obj), "utf-8")
 
 
+class PydanticJsonSerde(Serde[I]):
+    """
+    Serde for Pydantic models to/from JSON
+    """
+
+    def __init__(self, model):
+        self.model = model
+
+    def deserialize(self, buf: bytes) -> typing.Optional[I]:
+        """
+        Deserializes a bytearray to a Pydantic model.
+
+        Args:
+            buf (bytearray): The bytearray to deserialize.
+
+        Returns:
+            typing.Optional[I]: The deserialized Pydantic model.
+        """
+        if not buf:
+            return None
+        return self.model.model_validate_json(buf)
+
+    def serialize(self, obj: typing.Optional[I]) -> bytes:
+        """
+        Serializes a Pydantic model to a bytearray.
+
+        Args:
+            obj (I): The Pydantic model to serialize.
+
+        Returns:
+            bytearray: The serialized bytearray.
+        """
+        if obj is None:
+            return bytes()
+        json_str = obj.model_dump_json() # type: ignore[attr-defined]
+        return json_str.encode("utf-8")
+
 def deserialize_json(buf: typing.ByteString) -> typing.Optional[O]:
     """
     Deserializes a bytearray to a JSON object.

--- a/python/restate/service.py
+++ b/python/restate/service.py
@@ -84,8 +84,8 @@ class Service:
             def wrapped(*args, **kwargs):
                 return fn(*args, **kwargs)
 
-            arity = len(inspect.signature(fn).parameters)
-            handler = make_handler(self.service_tag, handler_io, name, None, wrapped, arity)
+            signature = inspect.signature(fn)
+            handler = make_handler(self.service_tag, handler_io, name, None, wrapped, signature)
             self.handlers[handler.name] = handler
             return wrapped
 

--- a/python/restate/workflow.py
+++ b/python/restate/workflow.py
@@ -114,8 +114,8 @@ class Workflow:
             def wrapped(*args, **kwargs):
                 return fn(*args, **kwargs)
 
-            arity = len(inspect.signature(fn).parameters)
-            handler = make_handler(self.service_tag, handler_io, name, kind, wrapped, arity)
+            signature = inspect.signature(fn)
+            handler = make_handler(self.service_tag, handler_io, name, kind, wrapped, signature)
             self.handlers[handler.name] = handler
             return wrapped
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
 (pkgs.buildFHSUserEnv {
-  name = "my-python-env";
+  name = "sdk-python";
   targetPkgs = pkgs: (with pkgs; [
     python3
     python3Packages.pip
@@ -10,6 +10,7 @@
 
 		# rust
 		rustup
+		cargo
     clang
     llvmPackages.bintools
     protobuf
@@ -29,6 +30,6 @@
   LIBCLANG_PATH = pkgs.lib.makeLibraryPath [ pkgs.llvmPackages_latest.libclang.lib ];
 
   runScript = ''
-    bash
+		bash
   '';
 }).env


### PR DESCRIPTION
This commit adds an optional support for pydantic models. To use this simply add the pydantic dependency, and annotate a handler with it.

```py

Greeting(BaseModel):
  name: str

@svc.handler()
async def greet(ctx, greeting: Greeting):
  ..
```

With this, any bad input (validation error) will result with a TerminalError thrown by the serializer.