### PR TITLE
add is-processing flag similar to typescript bindings

### DIFF
--- a/python/restate/vm.py
+++ b/python/restate/vm.py
@@ -345,3 +345,7 @@ class VMWrapper:
         It calls the `sys_end` method of the `vm` object.
         """
         self.vm.sys_end()
+
+    def is_processing(self) -> bool:
+        """Returns true if the VM is processing, and false if it is replaying execution"""
+        return self.vm.is_processing()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,6 +587,10 @@ impl PyVM {
     fn sys_end(mut self_: PyRefMut<'_, Self>) -> Result<(), PyVMError> {
         self_.vm.sys_end().map(Into::into).map_err(Into::into)
     }
+
+    fn is_processing(self_: PyRef<'_, Self>) -> bool {
+        self_.vm.is_processing()
+    }
 }
 
 #[pyclass]


### PR DESCRIPTION
This PR adds the is-processing flag to python sdk, needed to avoid duplicate logging 

Typescript sdk uses the same [logic](https://github.com/restatedev/sdk-typescript/blob/57a595a231b00c5f5014f34a0253e13d59a5de2a/sdk-shared-core-wasm-bindings/src/lib.rs#L705).