### PR TITLE
Feature/general serde

### DIFF
--- a/python/restate/handler.py
+++ b/python/restate/handler.py
@@ -72,7 +72,7 @@ def is_pydantic(annotation) -> bool:
         return False
 
 
-def extract_io_type_hints(handler_io: HandlerIO[I, O], signature: Signature):
+def update_handler_io_with_type_hints(handler_io: HandlerIO[I, O], signature: Signature):
     """
     Augment handler_io with additional information about the input and output types.
 
@@ -122,11 +122,6 @@ def make_handler(service_tag: ServiceTag,
                  signature: Signature) -> Handler[I, O]:
     """
     Factory function to create a handler.
-
-    Note:
-        This function mutates the `handler_io` parameter by updating its type hints
-        and serdes based on the function signature. Callers should be aware that the
-        passed `handler_io` instance will be modified.
     """
     # try to deduce the handler name
     handler_name = name
@@ -139,7 +134,7 @@ def make_handler(service_tag: ServiceTag,
         raise ValueError("Handler must have at least one parameter")
 
     arity = len(signature.parameters)
-    extract_io_type_hints(handler_io, signature) # mutates handler_io
+    update_handler_io_with_type_hints(handler_io, signature) # mutates handler_io
 
     handler = Handler[I, O](service_tag,
                             handler_io,

--- a/python/restate/object.py
+++ b/python/restate/object.py
@@ -17,7 +17,7 @@ from functools import wraps
 import inspect
 import typing
 
-from restate.serde import Serde, JsonSerde
+from restate.serde import Serde, GeneralSerde
 from .handler import HandlerIO, ServiceTag, make_handler
 
 I = typing.TypeVar('I')
@@ -54,8 +54,8 @@ class VirtualObject:
                 kind: typing.Optional[typing.Literal["exclusive", "shared"]] = "exclusive",
                 accept: str = "application/json",
                 content_type: str = "application/json",
-                input_serde: Serde[I] = JsonSerde[I](), # type: ignore
-                output_serde: Serde[O] = JsonSerde[O]()) -> typing.Callable: # type: ignore
+                input_serde: Serde[I] = GeneralSerde[I](), # type: ignore
+                output_serde: Serde[O] = GeneralSerde[O]()) -> typing.Callable: # type: ignore
         """
         Decorator for defining a handler function.
 

--- a/python/restate/serde.py
+++ b/python/restate/serde.py
@@ -156,7 +156,7 @@ class GeneralSerde(Serde[I]):
         Returns:
             bytes: The serialized byte array.
         """
-        
+
         if obj is None:
             return bytes()
 

--- a/python/restate/service.py
+++ b/python/restate/service.py
@@ -18,7 +18,7 @@ from functools import wraps
 import inspect
 import typing
 
-from restate.serde import Serde, JsonSerde
+from restate.serde import Serde, GeneralSerde
 from .handler import Handler, HandlerIO, ServiceTag, make_handler
 
 I = typing.TypeVar('I')
@@ -54,8 +54,8 @@ class Service:
                 name: typing.Optional[str] = None,
                 accept: str = "application/json",
                 content_type: str = "application/json",
-                input_serde: Serde[I] = JsonSerde[I](), # type: ignore
-                output_serde: Serde[O] = JsonSerde[O]()) -> typing.Callable: # type: ignore
+                input_serde: Serde[I] = GeneralSerde[I](), # type: ignore
+                output_serde: Serde[O] = GeneralSerde[O]()) -> typing.Callable: # type: ignore
         """
         Decorator for defining a handler function.
 

--- a/python/restate/workflow.py
+++ b/python/restate/workflow.py
@@ -18,7 +18,7 @@ from functools import wraps
 import inspect
 import typing
 
-from restate.serde import Serde, JsonSerde
+from restate.serde import Serde, GeneralSerde
 from .handler import HandlerIO, ServiceTag, make_handler
 
 I = typing.TypeVar('I')
@@ -57,8 +57,8 @@ class Workflow:
             name: typing.Optional[str] = None,
             accept: str = "application/json",
             content_type: str = "application/json",
-            input_serde: Serde[I] = JsonSerde[I](), # type: ignore
-            output_serde: Serde[O] = JsonSerde[O]()) -> typing.Callable: # type: ignore
+            input_serde: Serde[I] = GeneralSerde[I](), # type: ignore
+            output_serde: Serde[O] = GeneralSerde[O]()) -> typing.Callable: # type: ignore
         """Mark this handler as a workflow entry point"""
         return self._add_handler(name,
                             kind="workflow",
@@ -71,8 +71,8 @@ class Workflow:
                 name: typing.Optional[str] = None,
                 accept: str = "application/json",
                 content_type: str = "application/json",
-                input_serde: Serde[I] = JsonSerde[I](), # type: ignore
-                output_serde: Serde[O] = JsonSerde[O]()) -> typing.Callable: # type: ignore
+                input_serde: Serde[I] = GeneralSerde[I](), # type: ignore
+                output_serde: Serde[O] = GeneralSerde[O]()) -> typing.Callable: # type: ignore
         """
         Decorator for defining a handler function.
         """
@@ -83,8 +83,8 @@ class Workflow:
                 kind: typing.Literal["workflow", "shared", "exclusive"] = "shared",
                 accept: str = "application/json",
                 content_type: str = "application/json",
-                input_serde: Serde[I] = JsonSerde[I](), # type: ignore
-                output_serde: Serde[O] = JsonSerde[O]()) -> typing.Callable: # type: ignore
+                input_serde: Serde[I] = GeneralSerde[I](), # type: ignore
+                output_serde: Serde[O] = GeneralSerde[O]()) -> typing.Callable: # type: ignore
         """
         Decorator for defining a handler function.
 


### PR DESCRIPTION
Adds a general serde that can handle serialisation for both Pydantic objects and regular JSON objects. Tested for workflows, services and virtual objects.

Related to #45 