### PR TITLE
Add `select` future combinator

### DIFF
--- a/python/restate/__init__.py
+++ b/python/restate/__init__.py
@@ -22,7 +22,7 @@ from .context import WorkflowContext, WorkflowSharedContext
 # pylint: disable=line-too-long
 from .context import DurablePromise, RestateDurableFuture, RestateDurableCallFuture, RestateDurableSleepFuture, SendHandle
 from .exceptions import TerminalError
-from .asyncio import as_completed, gather, wait_completed
+from .asyncio import as_completed, gather, wait_completed, select
 
 from .endpoint import app
 
@@ -56,4 +56,5 @@ __all__ = [
     "gather",
     "as_completed",
     "wait_completed",
+    "select"
 ]


### PR DESCRIPTION
with that we can write code like that:

```python
 match await select(result=ctx.promise("verify.payment"), timeout=ctx.sleep(TIMEOUT)):
        case ['result', "approved"]:
            ctx.set("status", "payment approved")
            return { "success" : True }
        case ['result', "declined"]:
            ctx.set("status", "payment declined")
            raise TerminalError(message="Payment declined", status_code=401)
        case ['timeout', _]:
            ctx.set("status", "payment verification timed out")
            raise TerminalError(message="Payment verification timed out", status_code=410)
```