### PR TITLE
Try to auto deduce the types provided for ctx.run()

### DIFF
--- a/python/restate/context.py
+++ b/python/restate/context.py
@@ -145,19 +145,25 @@ class Context(abc.ABC):
             action: RunAction[T],
             serde: Serde[T] = DefaultSerde(),
             max_attempts: typing.Optional[int] = None,
-            max_retry_duration: typing.Optional[timedelta] = None) -> RestateDurableFuture[T]:
+            max_retry_duration: typing.Optional[timedelta] = None,
+            type_hint: Optional[typing.Type[T]] = None
+            ) -> RestateDurableFuture[T]:
         """
         Runs the given action with the given name.
 
         Args:
             name: The name of the action.
             action: The action to run.
-            serde: The serialization/deserialization mechanism.
+            serde: The serialization/deserialization mechanism. - if the default serde is used, a default serializer will be used based on the type. 
+                    See also 'type_hint'.
             max_attempts:   The maximum number of retry attempts to complete the action.
                             If None, the action will be retried indefinitely, until it succeeds.
                             Otherwise, the action will be retried until the maximum number of attempts is reached and then it will raise a TerminalError.
             max_retry_duration: The maximum duration for retrying. If None, the action will be retried indefinitely, until it succeeds.
                                 Otherwise, the action will be retried until the maximum duration is reached and then it will raise a TerminalError.
+            type_hint: The type hint of the return value of the action.
+                        This is used to pick the serializer. If None, the type hint will be inferred from the action's return type, or the provided serializer. 
+
         """
 
     @abc.abstractmethod

--- a/python/restate/handler.py
+++ b/python/restate/handler.py
@@ -20,7 +20,7 @@ from inspect import Signature
 from typing import Any, Callable, Awaitable, Dict, Generic, Literal, Optional, TypeVar
 
 from restate.exceptions import TerminalError
-from restate.serde import DefaultSerde, PydanticBaseModel, PydanticJsonSerde, Serde
+from restate.serde import DefaultSerde, PydanticJsonSerde, Serde, is_pydantic
 
 I = TypeVar('I')
 O = TypeVar('O')
@@ -62,16 +62,6 @@ class HandlerIO(Generic[I, O]):
     output_serde: Serde[O]
     input_type: Optional[TypeHint[I]] = None
     output_type: Optional[TypeHint[O]] = None
-
-def is_pydantic(annotation) -> bool:
-    """
-    Check if an object is a Pydantic model.
-    """
-    try:
-        return issubclass(annotation, PydanticBaseModel)
-    except TypeError:
-        # annotation is not a class or a type
-        return False
 
 
 def update_handler_io_with_type_hints(handler_io: HandlerIO[I, O], signature: Signature):


### PR DESCRIPTION
This commit try to deduce the type that is provided to the ctx.run(), in the case where a `serde` parameter is not passed. If type hints are there we will deduce the correct serializer from the type hints. If the type hints are not there, we will consult the `type_hint` parameter and try to deduce a serializer from there. If nothing worked, we will default to the DefaultSerde()