### PR TITLE
Support dataclasses serde

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,3 +1,4 @@
 hypercorn
 restate_sdk
 pydantic
+dacite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 test = ["pytest", "hypercorn"]
 lint = ["mypy", "pylint"]
 harness = ["testcontainers", "hypercorn", "httpx"]
+serde = ["dacite", "pydantic"]
 
 [build-system]
 requires = ["maturin>=1.6,<2.0"]


### PR DESCRIPTION
This commit adds an optional dependency to help
with dataclass serialization.
To use that one need to `pip install sdk_python[serde]`.