### PR TITLE
Rename created Docker image into test-services-python

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,34 +7,33 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 */6 * * *' # Every 6 hours
+    - cron: "0 */6 * * *" # Every 6 hours
   workflow_dispatch:
     inputs:
       restateCommit:
-        description: 'restate commit'
+        description: "restate commit"
         required: false
-        default: ''
+        default: ""
         type: string
       restateImage:
-        description: 'restate image, superseded by restate commit'
+        description: "restate image, superseded by restate commit"
         required: false
-        default: 'ghcr.io/restatedev/restate:main'
+        default: "ghcr.io/restatedev/restate:main"
         type: string
   workflow_call:
     inputs:
       restateCommit:
-        description: 'restate commit'
+        description: "restate commit"
         required: false
-        default: ''
+        default: ""
         type: string
       restateImage:
-        description: 'restate image, superseded by restate commit'
+        description: "restate image, superseded by restate commit"
         required: false
-        default: 'ghcr.io/restatedev/restate:main'
+        default: "ghcr.io/restatedev/restate:main"
         type: string
 
 jobs:
-
   sdk-test-suite:
     if: github.repository_owner == 'restatedev'
     runs-on: ubuntu-latest
@@ -99,7 +98,7 @@ jobs:
           file: "test-services/Dockerfile"
           push: false
           load: true
-          tags: restatedev/python-test-services
+          tags: restatedev/test-services-python
           cache-from: type=gha,scope=${{ github.workflow }}
           cache-to: type=gha,mode=max,scope=${{ github.workflow }}
 
@@ -107,6 +106,6 @@ jobs:
         uses: restatedev/sdk-test-suite@v3.0
         with:
           restateContainerImage: ${{ inputs.restateCommit != '' && 'localhost/restatedev/restate-commit-download:latest' || (inputs.restateImage != '' && inputs.restateImage || 'ghcr.io/restatedev/restate:main') }}
-          serviceContainerImage: "restatedev/python-test-services"
+          serviceContainerImage: "restatedev/test-services-python"
           exclusionsFile: "test-services/exclusions.yaml"
           testArtifactOutput: "sdk-python-integration-test-report"


### PR DESCRIPTION
I was confused by our naming pattern of the Docker image. The image that we are publishing is called test-services-python and the one we build in the integration workflow is called python-test-services. When reading the workflow run on GHA it took me quite some time to figure out where this image comes from.