### PR TITLE
Asgi recv() on lambda should hang when there are no more events

### DIFF
--- a/python/restate/aws_lambda.py
+++ b/python/restate/aws_lambda.py
@@ -87,16 +87,19 @@ def request_to_receive(req: RestateLambdaRequest) -> Receive:
         "type": "http.request",
         "body": body,
         "more_body": False
+    },
+    {
+        "type": "http.request",
+        "body": b'',
+        "more_body": False
     }])
 
     async def recv() -> HTTPRequestEvent:
         if len(events) != 0:
-            return events.pop()
-        return {
-            "type": "http.request",
-            "body": b'',
-            "more_body": False
-        }
+            return events.pop(0)
+        # If we are out of events, return a future that will never complete
+        f = asyncio.Future[HTTPRequestEvent]()
+        return await f
 
     return recv
 


### PR DESCRIPTION
This PR fixes a bug when running on AWS lambda. The asgi wrapper, before this commit, did not 'hang' when there are no more events to produce. With this commit when there are no more events we return a pending future.