### PR TITLE
Handle the `MAX_CONCURRENT_STREAMS` env var

### DIFF
--- a/test-services/entrypoint.sh
+++ b/test-services/entrypoint.sh
@@ -2,4 +2,10 @@
 
 PORT=${PORT:-"9080"}
 
+if [ -n "$MAX_CONCURRENT_STREAMS" ]; then
+    # respect the MAX_CONCURRENT_STREAMS environment variable
+    awk 'BEGIN { FS=OFS="=" } $1=="h2_max_concurrent_streams " {$2=" '$MAX_CONCURRENT_STREAMS'"} {print}' hypercorn-config.toml > hypercorn-config.toml.new
+    mv hypercorn-config.toml.new hypercorn-config.toml
+fi
+
 python3 -m hypercorn testservices:app --config hypercorn-config.toml --bind "0.0.0.0:${PORT}"


### PR DESCRIPTION
Handle the `MAX_CONCURRENT_STREAMS` env var

Summary:
Unify and apply the MAX_CONCURRENT_STREAMS env variable. This
same env var is used by the node test service as well to control
the h2 max concurrent streams
