### PR TITLE
Unification of the RESTATE_LOGGING env var

### DIFF
--- a/test-services/entrypoint.sh
+++ b/test-services/entrypoint.sh
@@ -8,4 +8,12 @@ if [ -n "$MAX_CONCURRENT_STREAMS" ]; then
     mv hypercorn-config.toml.new hypercorn-config.toml
 fi
 
+if [ -n "$RESTATE_LOGGING" ]; then
+    # unification of the RESTATE_LOGGING environment variable
+    # which is also used by the node-test-services.
+    #
+    # Set by the e2e-verification-runner
+    export RESTATE_CORE_LOG=$RESTATE_LOGGING
+fi
+
 python3 -m hypercorn testservices:app --config hypercorn-config.toml --bind "0.0.0.0:${PORT}"


### PR DESCRIPTION
Unification of the RESTATE_LOGGING env var

Summary:
The node-test-services honors the RESTATE_LOGGING env var, which
is set by the e2e-verification-test. This change make sure the
same env var is honored here by setting the proper logging var
