### PR TITLE
Fix ctx.time() ValueError for built-in time.time

### DIFF
--- a/python/restate/server_context.py
+++ b/python/restate/server_context.py
@@ -533,7 +533,7 @@ class ServerInvocationContext(ObjectContext):
         return UUID(int=self.random_instance.getrandbits(128), version=4)
 
     def time(self) -> RestateDurableFuture[float]:
-        return self.run_typed("timestamp", time.time)
+        return self.run_typed("timestamp", lambda: time.time())
 
     # pylint: disable=R0914
     async def create_run_coroutine(self,


### PR DESCRIPTION
Fix ctx.time() ValueError by wrapping time.time in a lambda

- Replaced direct call to built-in time.time with a lambda in server_context.py
- Prevents inspect.signature error for built-in functions when using ctx.run_typed

