### PR TITLE
feat: add msgspec support

### DIFF
--- a/examples/msgspec_greeter.py
+++ b/examples/msgspec_greeter.py
@@ -1,0 +1,38 @@
+#
+#  Copyright (c) 2023-2025 - Restate Software, Inc., Restate GmbH
+#
+#  This file is part of the Restate SDK for Python,
+#  which is released under the MIT license.
+#
+#  You can find a copy of the license in file LICENSE in the root
+#  directory of this repository or package, or at
+#  https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+#
+"""msgspec_greeter.py - Example using msgspec.Struct with Restate"""
+# pylint: disable=C0116
+# pylint: disable=W0613
+# pylint: disable=C0115
+# pylint: disable=R0903
+
+import msgspec
+from restate import Service, Context
+
+
+# models
+class GreetingRequest(msgspec.Struct):
+    name: str
+
+
+class Greeting(msgspec.Struct):
+    message: str
+
+
+# service
+
+msgspec_greeter = Service("msgspec_greeter")
+
+
+@msgspec_greeter.handler()
+async def greet(ctx: Context, req: GreetingRequest) -> Greeting:
+    return Greeting(message=f"Hello {req.name}!")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ Source = "https://github.com/restatedev/sdk-python"
 test = ["pytest", "hypercorn", "anyio"]
 lint = ["mypy>=1.11.2", "pyright>=1.1.390", "ruff>=0.6.9"]
 harness = ["testcontainers", "hypercorn", "httpx"]
-serde = ["dacite", "pydantic"]
+serde = ["dacite", "pydantic", "msgspec"]
 client = ["httpx[http2]"]
 
 [build-system]

--- a/python/restate/discovery.py
+++ b/python/restate/discovery.py
@@ -218,6 +218,10 @@ def json_schema_from_type_hint(type_hint: Optional[TypeHint[Any]]) -> Any:
         return None
     if not type_hint.annotation:
         return None
+    if type_hint.is_msgspec:
+        import msgspec.json  # type: ignore # pylint: disable=import-outside-toplevel
+
+        return msgspec.json.schema(type_hint.annotation)
     if type_hint.is_pydantic:
         return type_hint.annotation.model_json_schema(mode="serialization")
     return type_hint_to_json_schema(type_hint.annotation)


### PR DESCRIPTION
### Summary

Adds support for [msgspec](https://jcristharif.com/msgspec/) `Struct` types in Restate SDK Python handlers, following the same pattern as existing Pydantic support.
Closes #146 

Accompanying docs PR: https://github.com/restatedev/docs-restate/pull/98

### Changes

#### Core Implementation

- `python/restate/serde.py` - Added `MsgspecJsonSerde` class and msgspec type detection
- `python/restate/handler.py` - Added automatic msgspec type detection and serde selection (priority: msgspec → Pydantic → dataclass → JSON)
- `python/restate/discovery.py` - Added JSON schema generation for msgspec types using `msgspec.json.schema()`
- `pyproject.toml` - Added `msgspec` to `serde` optional dependencies

#### Example

Added `examples/msgspec_greeter.py` demonstrating `msgspec.Struct` usage, mirroring the existing `pydantic_greeter.py` example.

### Testing

#### Test Script

<details>
<summary>A standalone test script</summary>

```python
# /// script
# requires-python = ">=3.12"
# dependencies = [
#     "msgspec>=0.19.0",
#     "hypercorn>=0.18.0",
#     "restate-sdk @ file:///home/fdra/_dev/state/resources/sdk-python",
# ]
# ///
"""
Standalone test script for msgspec support in Restate SDK Python

"""

import asyncio

import msgspec
import restate
from restate import Context, Service


# Define msgspec models
class GreetingRequest(msgspec.Struct):
    """Request model using msgspec.Struct"""
    name: str
    title: str = "Mr/Ms"


class GreetingResponse(msgspec.Struct):
    """Response model using msgspec.Struct"""
    message: str
    timestamp: int = 0


class UserProfile(msgspec.Struct):
    """Complex nested model"""
    user_id: int
    username: str
    email: str
    active: bool = True


# Create service
greeter = Service("MsgspecGreeter")


@greeter.handler()
async def greet(ctx: Context, req: GreetingRequest) -> GreetingResponse:
    """Handler that uses msgspec.Struct for input and output"""
    import time
    message = f"Hello {req.title} {req.name}!"
    return GreetingResponse(message=message, timestamp=int(time.time()))


@greeter.handler()
async def simple_greet(ctx: Context, name: str) -> str:
    """Handler with simple string input/output"""
    return f"Hi {name}!"


@greeter.handler()
async def create_profile(ctx: Context, profile: UserProfile) -> UserProfile:
    """Handler that echoes back a complex msgspec.Struct"""
    # Just echo back the profile to test msgspec serialization/deserialization
    return profile


@greeter.handler()
async def get_profile(ctx: Context, user_id: int) -> UserProfile:
    """Handler that creates a profile based on user_id"""
    # Return a profile to test msgspec serialization
    return UserProfile(
        user_id=user_id,
        username=f"user_{user_id}",
        email=f"user{user_id}@example.com"
    )


if __name__ == "__main__":
    import msgspec
    import restate
    import hypercorn
    import hypercorn.asyncio

    app = restate.app([greeter])
    conf = hypercorn.Config()
    conf.bind = ["0.0.0.0:9080"]
    asyncio.run(hypercorn.asyncio.serve(app, conf))

```
</details>

#### Running Tests

**Prerequisites:**
```bash
# Start Restate server
podman run --name restate_dev --rm \
  -p 8080:8080 -p 9070:9070 -p 5122:5122 \
  --add-host=host.docker.internal:host-gateway \
  docker.restate.dev/restatedev/restate:1.5.3 --log-format=compact
```

**Run the test service:**
```bash
uv run test_msgspec_standalone.py
```

**Register the service:**
```bash
curl -X POST http://localhost:9070/deployments \
  -H 'Content-Type: application/json' \
  -d '{"uri": "http://host.docker.internal:9080"}'
```

#### Test Cases

```bash
# Test 1: Complex msgspec.Struct Input/Output
curl -X POST http://localhost:8080/MsgspecGreeter/greet \
  -H 'Content-Type: application/json' \
  -d '{"name": "Alice", "title": "Dr"}'
# Response: {"message":"Hello Dr Alice!","timestamp":1763887409}

# Test 2: Simple String Input/Output
curl -X POST http://localhost:8080/MsgspecGreeter/simple_greet \
  -H 'Content-Type: application/json' \
  -d '"Bob"'
# Response: "Hi Bob!"

# Test 3: Complex Nested msgspec.Struct Echo
curl -X POST http://localhost:8080/MsgspecGreeter/create_profile \
  -H 'Content-Type: application/json' \
  -d '{"user_id": 123, "username": "charlie", "email": "charlie@example.com", "active": true}'
# Response: {"user_id":123,"username":"charlie","email":"charlie@example.com","active":true}

# Test 4: Integer Input → msgspec.Struct Output
curl -X POST http://localhost:8080/MsgspecGreeter/get_profile \
  -H 'Content-Type: application/json' \
  -d '456'
# Response: {"user_id":456,"username":"user_456","email":"user456@example.com","active":true}
```
