### PR TITLE
Use DefaultSerde instead of JsonSerde for promise() default parameter

### DIFF
--- a/python/restate/server_context.py
+++ b/python/restate/server_context.py
@@ -47,7 +47,7 @@ from restate.context import (
 )
 from restate.exceptions import TerminalError, SdkInternalBaseException, SdkInternalException, SuspendedException
 from restate.handler import Handler, handler_from_callable, invoke_handler
-from restate.serde import BytesSerde, DefaultSerde, JsonSerde, Serde
+from restate.serde import BytesSerde, DefaultSerde, Serde
 from restate.server_types import ReceiveChannel, Send
 from restate.vm import Failure, Invocation, NotReady, VMWrapper, RunRetryConfig, Suspended  # pylint: disable=line-too-long
 from restate.vm import (
@@ -939,7 +939,7 @@ class ServerInvocationContext(ObjectContext):
         update_restate_context_is_replaying(self.vm)
 
     def promise(
-        self, name: str, serde: typing.Optional[Serde[T]] = JsonSerde(), type_hint: Optional[typing.Type[T]] = None
+        self, name: str, serde: typing.Optional[Serde[T]] = DefaultSerde(), type_hint: Optional[typing.Type[T]] = None
     ) -> DurablePromise[T]:
         """Create a durable promise."""
         if isinstance(serde, DefaultSerde):


### PR DESCRIPTION
## Summary
Fixes the default serde parameter in `ServerInvocationContext.promise()` to use `DefaultSerde()` instead of `JsonSerde()`, aligning with the interface definition in `WorkflowContext`.

## Changes
- Changed default parameter from `JsonSerde()` to `DefaultSerde()` in `promise()` method
- Removed unused `JsonSerde` import
- Add unit test that verifies if the default for promise() is DefaultSerde

## Motivation
The default serde is supposed to be `DefaultSerde`, as defined in `WorkflowContext`. This bug forces users to explicitly declare `serde=DefaultSerde()`, even though it is already documented as the default in `WorkflowContext`.
[Slack thread that originated this PR](https://restatecommunity.slack.com/archives/C0821C5RBH9/p1764779069226659)

## Testing
- ✅ All linting checks pass
- ✅ Type checking passes (pyright & mypy)
- ✅ All 10 unit tests pass


### Linting
```
  $ uv run ruff format
  53 files left unchanged

  $ uv run ruff check
  All checks passed!
```
###  Type Checking
```
  $ PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright python/
  0 errors, 0 warnings, 0 informations

  $ uv run mypy --check-untyped-defs --ignore-missing-imports python/
  Success: no issues found in 24 source files
```
###  Unit Tests
```
  $ uv run pytest tests/*.py -v
  ============================= test session starts ==============================
  platform darwin -- Python 3.12.0, pytest-8.4.2, pluggy-1.6.0
  rootdir: /Users/gustavogomes/projects/sdk-python
  configfile: pyproject.toml
  plugins: anyio-4.11.0
  collecting ... collected 11 items

  tests/ext.py::test_greeter PASSED                                        [  9%]
  tests/ext.py::test_greeter_with_cm PASSED                                [ 18%]
  tests/harness.py::test_greeter PASSED                                    [ 27%]
  tests/harness.py::test_counter PASSED                                    [ 36%]
  tests/harness.py::test_idempotency_key PASSED                            [ 45%]
  tests/harness.py::test_workflow PASSED                                   [ 54%]
  tests/harness.py::test_send PASSED                                       [ 63%]
  tests/serde.py::test_bytes_serde PASSED                                  [ 72%]
  tests/servercontext.py::test_sanity PASSED                               [ 81%]
  tests/servercontext.py::test_wrapped_terminal_exception PASSED           [ 90%]
  tests/servercontext.py::test_promise_default_serde PASSED                [100%]

  ============================= 11 passed in 16.04s ==============================
```
