### PR TITLE
Replace traceback.print_exc() with logger.exception() for proper logging

### DIFF
--- a/python/restate/server.py
+++ b/python/restate/server.py
@@ -11,8 +11,8 @@
 """This module contains the ASGI server for the restate framework."""
 
 import asyncio
+import logging
 from typing import Dict, TypedDict, Literal
-import traceback
 
 from restate.discovery import compute_discovery_json
 from restate.endpoint import Endpoint
@@ -23,6 +23,8 @@ from restate.aws_lambda import is_running_on_lambda, wrap_asgi_as_lambda_handler
 
 from restate._internal import PyIdentityVerifier, IdentityVerificationException  # pylint: disable=import-error,no-name-in-module
 from restate._internal import SDK_VERSION  # pylint: disable=import-error,no-name-in-module
+
+logger = logging.getLogger(__name__)
 
 X_RESTATE_SERVER = header_to_binary([("x-restate-server", f"restate-sdk-python/{SDK_VERSION}")])
 
@@ -165,7 +167,7 @@ async def process_invocation_to_completion(
         return
     # pylint: disable=W0718
     except Exception:
-        traceback.print_exc()
+        logger.exception("Exception in Restate handler")
     try:
         await context.leave()
     finally:
@@ -272,7 +274,7 @@ def asgi_app(endpoint: Endpoint) -> RestateAppT:
         except LifeSpanNotImplemented as e:
             raise e
         except Exception as e:
-            traceback.print_exc()
+            logger.exception("Exception in ASGI app")
             raise e
 
     if is_running_on_lambda():

--- a/python/restate/server_context.py
+++ b/python/restate/server_context.py
@@ -24,6 +24,7 @@ from random import Random
 from datetime import timedelta
 import inspect
 import functools
+import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar, Union, Coroutine
 import typing
 import traceback
@@ -59,6 +60,7 @@ from restate.vm import (
     DoWaitPendingRun,
 )
 
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 I = TypeVar("I")
@@ -448,8 +450,7 @@ class ServerInvocationContext(ObjectContext):
         if isinstance(res, Exception):
             # We might need to write out something at this point.
             await self.take_and_send_output()
-            # Print this exception, might be relevant for the user
-            traceback.print_exception(res)
+            logger.exception("Exception in take_notification", exc_info=res)
             raise SdkInternalException() from res
         if isinstance(res, Suspended):
             # We might need to write out something at this point.
@@ -469,8 +470,7 @@ class ServerInvocationContext(ObjectContext):
             await self.take_and_send_output()
             do_progress_response = self.vm.do_progress(handles)
             if isinstance(do_progress_response, BaseException):
-                # Print this exception, might be relevant for the user
-                traceback.print_exception(do_progress_response)
+                logger.exception("Exception in do_progress", exc_info=do_progress_response)
                 raise SdkInternalException() from do_progress_response
             if isinstance(do_progress_response, Suspended):
                 raise SuspendedException()


### PR DESCRIPTION
## Problem

The SDK currently uses `traceback.print_exc()` and `traceback.print_exception()` which write directly to stderr, bypassing Python's logging system. This prevents applications from:

- Configuring log destinations (files, syslog, cloud services)
- Controlling log levels and filtering
- Using structured logging formats (JSON, etc.)
- Integrating with monitoring and alerting systems

[PEP 337: Logging Usage in the Standard Library](https://peps.python.org/pep-0337/) explicitly states:
> "Replace `traceback.print_exception` with `_log.exception`"

And recommends that modules should:
> "use the logging system instead of `print` or `sys.stdout.write`"

## Solution

Replaced all instances of `traceback.print_exc()` and `traceback.print_exception()` with `logger.exception()`, following the recommendation from **PEP 337**.

### Changes
- Added `logging.getLogger(__name__)` to `server.py` and `server_context.py`
- Replaced `traceback.print_exc()` with `logger.exception()` in 2 locations
- Replaced `traceback.print_exception()` with `logger.exception()` in 2 locations
- Removed unused `traceback` import from `server.py`

### Testing

  All checks pass successfully:
 
  ```bash
  $ uv run ruff format
  53 files left unchanged

  $ uv run ruff check
  All checks passed!


  $ PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright python/
  0 errors, 0 warnings, 0 informations

  $ uv run mypy --check-untyped-defs --ignore-missing-imports python/
  Success: no issues found in 24 source files

  $ uv run pytest tests/*.py -v
  ============================= test session starts ==============================
  platform darwin -- Python 3.12.0, pytest-8.4.2, pluggy-1.6.0 -- /Users/gustavogomes/projects/sdk-python/.venv/bin/python3
  cachedir: .pytest_cache
  rootdir: /Users/gustavogomes/projects/sdk-python
  configfile: pyproject.toml
  plugins: anyio-4.11.0
  collecting ... collected 13 items

  tests/ext.py::test_greeter PASSED                                        [  7%]
  tests/ext.py::test_greeter_with_cm PASSED                                [ 15%]
  tests/harness.py::test_greeter PASSED                                    [ 23%]
  tests/harness.py::test_counter PASSED                                    [ 30%]
  tests/harness.py::test_idempotency_key PASSED                            [ 38%]
  tests/harness.py::test_workflow PASSED                                   [ 46%]
  tests/harness.py::test_send PASSED                                       [ 53%]
  tests/serde.py::test_bytes_serde PASSED                                  [ 61%]
  tests/servercontext.py::test_sanity PASSED                               [ 69%]
  tests/servercontext.py::test_wrapped_terminal_exception PASSED           [ 76%]
  tests/servercontext.py::test_promise_default_serde PASSED                [ 84%]
  tests/servercontext.py::test_handler_with_union_none PASSED              [ 92%]
  tests/servercontext.py::test_handler_with_ctx_none PASSED                [100%]

  ============================= 13 passed in 22.47s ==============================
```
