### PR TITLE
Agent integrations: remove default retries

### DIFF
--- a/python/restate/ext/adk/plugin.py
+++ b/python/restate/ext/adk/plugin.py
@@ -222,8 +222,4 @@ async def _generate_content_async(
         finally:
             await a_gen.aclose()
 
-    return await ctx.run_typed(
-        "call LLM",
-        call_llm,
-        run_options,
-    )
+    return await ctx.run_typed("call LLM", call_llm, run_options)

--- a/python/restate/ext/adk/plugin.py
+++ b/python/restate/ext/adk/plugin.py
@@ -14,7 +14,6 @@ ADK plugin implementation for restate.
 
 import restate
 
-from datetime import timedelta
 from typing import Optional, Any, cast
 
 from google.genai import types
@@ -93,9 +92,9 @@ class PluginState:
 class RestatePlugin(BasePlugin):
     """A plugin to integrate Restate with the ADK framework."""
 
-    def __init__(self, *, max_model_call_retries: int = 10):
+    def __init__(self, *, run_options: restate.RunOptions | None = None):
         super().__init__(name="restate_plugin")
-        self._max_model_call_retries = max_model_call_retries
+        self._run_options = run_options if run_options is not None else restate.RunOptions()
 
     async def before_agent_callback(
         self, *, agent: BaseAgent, callback_context: CallbackContext
@@ -137,7 +136,7 @@ class RestatePlugin(BasePlugin):
             )
         state = PluginState.from_context(callback_context.invocation_id, ctx)
         model = state.model
-        response = await _generate_content_async(ctx, self._max_model_call_retries, model, llm_request)
+        response = await _generate_content_async(ctx, self._run_options, model, llm_request)
         turnstile = _create_turnstile(response)
         state.turnstile = turnstile
         return response
@@ -210,7 +209,7 @@ def _generate_client_function_call_id(s: LlmResponse) -> None:
 
 
 async def _generate_content_async(
-    ctx: restate.Context, max_attempts: int, model: BaseLlm, llm_request: LlmRequest
+    ctx: restate.Context, run_options: restate.RunOptions, model: BaseLlm, llm_request: LlmRequest
 ) -> LlmResponse:
     """Generate content using Restate's context."""
 
@@ -226,5 +225,5 @@ async def _generate_content_async(
     return await ctx.run_typed(
         "call LLM",
         call_llm,
-        restate.RunOptions(max_attempts=max_attempts, initial_retry_interval=timedelta(seconds=1)),
+        run_options,
     )

--- a/python/restate/ext/openai/__init__.py
+++ b/python/restate/ext/openai/__init__.py
@@ -18,7 +18,6 @@ from restate import ObjectContext, Context
 from restate.server_context import current_context
 
 from .runner_wrapper import DurableRunner
-from .models import LlmRetryOpts
 from .functions import propagate_cancellation, raise_terminal_errors, durable_function_tool
 
 
@@ -40,7 +39,6 @@ def restate_context() -> Context:
 
 __all__ = [
     "DurableRunner",
-    "LlmRetryOpts",
     "restate_object_context",
     "restate_context",
     "raise_terminal_errors",

--- a/python/restate/ext/openai/models.py
+++ b/python/restate/ext/openai/models.py
@@ -12,16 +12,12 @@
 This module contains the optional OpenAI integration for Restate.
 """
 
-import dataclasses
-
 from agents import (
     Usage,
     AgentsException,
 )
 from agents.items import TResponseOutputItem
 from agents.items import TResponseInputItem
-from datetime import timedelta
-from typing import Optional
 from pydantic import BaseModel
 
 from restate.ext.turnstile import Turnstile
@@ -33,32 +29,6 @@ class State:
 
     def __init__(self) -> None:
         self.turnstile = Turnstile([])
-
-
-@dataclasses.dataclass
-class LlmRetryOpts:
-    max_attempts: Optional[int] = 10
-    """Max number of attempts (including the initial), before giving up.
-
-    When giving up, the LLM call will throw a `TerminalError` wrapping the original error message."""
-    max_duration: Optional[timedelta] = None
-    """Max duration of retries, before giving up.
-
-    When giving up, the LLM call will throw a `TerminalError` wrapping the original error message."""
-    initial_retry_interval: Optional[timedelta] = timedelta(seconds=1)
-    """Initial interval for the first retry attempt.
-    Retry interval will grow by a factor specified in `retry_interval_factor`.
-
-    If any of the other retry related fields is specified, the default for this field is 50 milliseconds, otherwise restate will fallback to the overall invocation retry policy."""
-    max_retry_interval: Optional[timedelta] = None
-    """Max interval between retries.
-    Retry interval will grow by a factor specified in `retry_interval_factor`.
-
-    The default is 10 seconds."""
-    retry_interval_factor: Optional[float] = None
-    """Exponentiation factor to use when computing the next retry delay.
-
-    If any of the other retry related fields is specified, the default for this field is `2`, meaning retry interval will double at each attempt, otherwise restate will fallback to the overall invocation retry policy."""
 
 
 # The OpenAI ModelResponse class is a dataclass with Pydantic fields.

--- a/python/restate/ext/openai/runner_wrapper.py
+++ b/python/restate/ext/openai/runner_wrapper.py
@@ -32,7 +32,7 @@ from restate.extensions import current_context
 from restate import RunOptions, TerminalError
 
 from .functions import get_function_call_ids, wrap_agent_tools
-from .models import LlmRetryOpts, RestateModelResponse, State
+from .models import RestateModelResponse, State
 from .session import RestateSession
 
 
@@ -41,7 +41,7 @@ class DurableModelCalls(MultiProvider):
     A Restate model provider that wraps the OpenAI SDK's default MultiProvider.
     """
 
-    def __init__(self, state: State, llm_retry_opts: LlmRetryOpts | None = None):
+    def __init__(self, state: State, llm_retry_opts: RunOptions | None = None):
         super().__init__()
         self.llm_retry_opts = llm_retry_opts
         self.state = state
@@ -56,11 +56,11 @@ class RestateModelWrapper(Model):
     A wrapper around the OpenAI SDK's Model that persists LLM calls in the Restate journal.
     """
 
-    def __init__(self, model: Model, state: State, llm_retry_opts: LlmRetryOpts | None = None):
+    def __init__(self, model: Model, state: State, llm_run_options: RunOptions | None = None):
         self.model = model
         self.state = state
         self.model_name = "RestateModelWrapper"
-        self.llm_retry_opts = llm_retry_opts if llm_retry_opts is not None else LlmRetryOpts()
+        self.llm_run_options = llm_run_options if llm_run_options is not None else RunOptions()
 
     async def get_response(self, *args, **kwargs) -> ModelResponse:
         async def call_llm() -> RestateModelResponse:
@@ -78,13 +78,7 @@ class RestateModelWrapper(Model):
         result = await ctx.run_typed(
             "call LLM",
             call_llm,
-            RunOptions(
-                max_attempts=self.llm_retry_opts.max_attempts,
-                max_duration=self.llm_retry_opts.max_duration,
-                initial_retry_interval=self.llm_retry_opts.initial_retry_interval,
-                max_retry_interval=self.llm_retry_opts.max_retry_interval,
-                retry_interval_factor=self.llm_retry_opts.retry_interval_factor,
-            ),
+            self.llm_run_options,
         )
         # collect function call IDs, too
         ids = get_function_call_ids(result.output)

--- a/python/restate/ext/openai/runner_wrapper.py
+++ b/python/restate/ext/openai/runner_wrapper.py
@@ -41,7 +41,7 @@ class DurableModelCalls(MultiProvider):
     A Restate model provider that wraps the OpenAI SDK's default MultiProvider.
     """
 
-    def __init__(self, state: State, llm_retry_opts: RunOptions | None = None):
+    def __init__(self, state: State, llm_retry_opts: RunOptions):
         super().__init__()
         self.llm_retry_opts = llm_retry_opts
         self.state = state
@@ -56,11 +56,11 @@ class RestateModelWrapper(Model):
     A wrapper around the OpenAI SDK's Model that persists LLM calls in the Restate journal.
     """
 
-    def __init__(self, model: Model, state: State, llm_run_options: RunOptions | None = None):
+    def __init__(self, model: Model, state: State, llm_run_options: RunOptions):
         self.model = model
         self.state = state
         self.model_name = "RestateModelWrapper"
-        self.llm_run_options = llm_run_options if llm_run_options is not None else RunOptions()
+        self.llm_run_options = llm_run_options
 
     async def get_response(self, *args, **kwargs) -> ModelResponse:
         async def call_llm() -> RestateModelResponse:
@@ -110,6 +110,7 @@ class DurableRunner:
         input: str | list[TResponseInputItem],
         *,
         use_restate_session: bool = False,
+        run_options: RunOptions | None = None,
         **kwargs,
     ) -> RunResult:
         """
@@ -118,6 +119,7 @@ class DurableRunner:
         Args:
             use_restate_session: If True, creates a RestateSession for conversation persistence.
                                 Requires running within a Restate Virtual Object context.
+            run_options: RunOptions to use for the LLM call.
 
         Returns:
             The result from Runner.run
@@ -127,7 +129,7 @@ class DurableRunner:
         state = State()
 
         # Set persisting model calls
-        llm_retry_opts = kwargs.pop("llm_retry_opts", None)
+        llm_retry_opts = run_options if run_options is not None else RunOptions()
         run_config = kwargs.pop("run_config", RunConfig())
         run_config = dataclasses.replace(run_config, model_provider=DurableModelCalls(state, llm_retry_opts))
 

--- a/python/restate/ext/pydantic/_agent.py
+++ b/python/restate/ext/pydantic/_agent.py
@@ -103,7 +103,7 @@ class RestateAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         self._auto_wrap_tools = auto_wrap_tools
 
         if run_options is None:
-            run_options = RunOptions(max_attempts=10, initial_retry_interval=timedelta(seconds=1))
+            run_options = RunOptions()
 
         self._model = RestateModelWrapper(wrapped.model, run_options, event_stream_handler=event_stream_handler)
 


### PR DESCRIPTION
From user feedback, we understand that the default retry policies set on our agent integrations are confusing since they are not easily discoverable and the interaction with service/handler-level retry policies is not obvious. 

Therefore, this PR removes the default retry policies from all AI integrations: Pydantic AI, Google ADK, and OpenAI Agents. 

It is still possible to set RunOptions at the agent level. Those are used for LLM calls, and if supported also for auto-wrapped tools, and MCP clients. 