### PR TITLE
fix: Handle signal registration outside the main thread

### DIFF
--- a/python/restate/server.py
+++ b/python/restate/server.py
@@ -228,7 +228,7 @@ def asgi_app(endpoint: Endpoint) -> RestateAppT:
             loop = asyncio.get_running_loop()
             try:
                 loop.add_signal_handler(signal.SIGTERM, _on_sigterm)
-        except (NotImplementedError, RuntimeError, ValueError):
+            except (NotImplementedError, RuntimeError, ValueError):
                 pass  # Windows or non-main thread
             sigterm_installed = True
         try:

--- a/python/restate/server.py
+++ b/python/restate/server.py
@@ -228,7 +228,7 @@ def asgi_app(endpoint: Endpoint) -> RestateAppT:
             loop = asyncio.get_running_loop()
             try:
                 loop.add_signal_handler(signal.SIGTERM, _on_sigterm)
-            except (NotImplementedError, RuntimeError):
+        except (NotImplementedError, RuntimeError, ValueError):
                 pass  # Windows or non-main thread
             sigterm_installed = True
         try:

--- a/tests/server.py
+++ b/tests/server.py
@@ -59,4 +59,5 @@ async def test_signal_handler_rejection_does_not_fail_request(monkeypatch: pytes
         send,
     )
 
-    assert {message.get("status") for message in sent} == {200}
+    response_starts = [message for message in sent if message["type"] == "http.response.start"]
+    assert [message["status"] for message in response_starts] == [200]

--- a/tests/server.py
+++ b/tests/server.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from restate.server import Endpoint
+from restate.endpoint import Endpoint
 
 
 @pytest.fixture(scope="session")

--- a/tests/server.py
+++ b/tests/server.py
@@ -1,0 +1,62 @@
+#
+#  Copyright (c) 2023-2025 - Restate Software, Inc., Restate GmbH
+#
+#  This file is part of the Restate SDK for Python,
+#  which is released under the MIT license.
+#
+#  You can find a copy of the license in file LICENSE in the root
+#  directory of this repository or package, or at
+#  https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+#
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from restate.server import Endpoint
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    return "asyncio"
+
+
+pytestmark = [pytest.mark.anyio]
+
+
+async def test_signal_handler_rejection_does_not_fail_request(monkeypatch: pytest.MonkeyPatch):
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(
+        loop,
+        "add_signal_handler",
+        Mock(side_effect=ValueError("add_signal_handler() can only be called from the main thread")),
+    )
+
+    app = Endpoint().app()
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await app(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/restate/health",
+            "raw_path": b"/restate/health",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "server": ("127.0.0.1", 9080),
+        },
+        receive,
+        send,
+    )
+
+    assert {message.get("status") for message in sent} == {200}


### PR DESCRIPTION
## Summary

- tolerate `ValueError` when an event loop rejects `add_signal_handler()`
- add an ASGI health-request regression test that reproduces the rejection without depending on uvloop internals

## Root cause

Restate installs a SIGTERM handler while serving the ASGI application. The existing code handles `NotImplementedError` and `RuntimeError`, which covers unsupported platforms and asyncio's behavior outside the main thread.

uvloop raises `ValueError` instead when `add_signal_handler()` is called outside the main thread. Granian runs each ASGI worker on its own thread, so Restate requests failed with:

```
ValueError: add_signal_handler() can only be called from the main thread
```

This was observed with Granian, uvloop, and free-threaded CPython 3.14.6. Switching Granian to the asyncio loop avoided the exception, but lost the desired uvloop runtime.

## Impact

The additional exception handling lets Restate applications run under Granian worker threads with uvloop, including free-threaded Python deployments. Signal registration remains best-effort, matching the existing behavior for asyncio and unsupported platforms.

No Granian-specific or uvloop-specific runtime patch is introduced.

## Validation

- branch rebased on current `restatedev/sdk-python:main`
- `git diff --check` passed
- regression test added for a successful `GET /restate/health` when signal registration raises `ValueError`
- local pytest execution was attempted, but the editable Rust extension build stalled in `cargo metadata` at zero CPU due to unrelated long-running Cargo jobs on the development machine; upstream CI should execute the focused test

